### PR TITLE
Support TMUX as default tmate socket in humacs+doom

### DIFF
--- a/config.org
+++ b/config.org
@@ -1,3 +1,4 @@
+#+TITLE: Humacs Default Doom Config
 #+PROPERTY: header-args:elisp+ :results silent
 
 *  Humac Human Deets
@@ -148,6 +149,7 @@ This is an adjustment to the default hook, which hides drawers by default
 
 ** Pairing
 #+BEGIN_SRC elisp
+(use-package! sql)
 (use-package! osc52e)
 (use-package! iterm)
 (use-package! ob-tmate)
@@ -172,6 +174,39 @@ In addition to the org defaults, we wanna make sure our exports include results,
       '((:results . "output code verbatim replace")
         (:wrap . "example")))
 #+END_SRC
+** Support Big Query
+#+begin_src elisp
+(defun ii-sql-comint-bq (product options &optional buf-name)
+  "Create a bq shell in a comint buffer."
+  ;; We may have 'options' like database later
+  ;; but for the most part, ensure bq command works externally first
+  (sql-comint product options buf-name)
+  )
+(defun ii-sql-bq (&optional buffer)
+  "Run bq by Google as an inferior process."
+  (interactive "P")
+  (sql-product-interactive 'bq buffer)
+  )
+(after! sql
+  (sql-add-product 'bq "Google Big Query"
+                   :free-software nil
+                   ;; :font-lock 'bqm-font-lock-keywords ; possibly later?
+                   ;; :syntax-alist 'bqm-mode-syntax-table ; invalid
+                   :prompt-regexp "^[[:alnum:]-]+> "
+                   ;; I don't think we have a continuation prompt
+                   ;; but org-babel-execute:sql-mode requires it
+                   ;; otherwise re-search-forward errors on nil
+                   ;; when it requires a string
+                   :prompt-cont-regexp "3a83b8c2z93c89889a4c98r2z34"
+                   ;; :prompt-length 9 ; can't precalculate this
+                   :sqli-program "bq"
+                   :sqli-login nil ; probably just need to preauth
+                   :sqli-options '("shell" "--quiet" "--format" "pretty")
+                   :sqli-comint-func 'ii-sql-comint-bq
+                 )
+  )
+#+end_src
+
 
 * Snippets
 These are helpful text expanders made with yasnippet

--- a/config.org
+++ b/config.org
@@ -154,6 +154,7 @@ This is an adjustment to the default hook, which hides drawers by default
 #+END_SRC
 ** Pairing
 #+BEGIN_SRC elisp
+(use-package! graphviz-dot-mode)
 (use-package! sql)
 (use-package! osc52e)
 (use-package! iterm)

--- a/config.org
+++ b/config.org
@@ -146,7 +146,12 @@ This is an adjustment to the default hook, which hides drawers by default
       '((:results . "replace code")
         (:wrap . "SRC example")))
 #+END_SRC
-
+** OSC52 (copy over ssh/terminal)
+#+BEGIN_SRC elisp
+(after! osc52e
+  (osc52-set-cut-function)
+  )
+#+END_SRC
 ** Pairing
 #+BEGIN_SRC elisp
 (use-package! sql)

--- a/local/ob-tmate/ob-tmate.el
+++ b/local/ob-tmate/ob-tmate.el
@@ -97,18 +97,15 @@ Uses kitty if found, otherwise iterm on OSX"
   `((:results . "silent")
     (:session . "tmate")
     (:window . "i")
-    (:dir . "."))
-  ;; TODO revisit the socket.  when i tried to load it on doom,
-  ;;      I got an error that the function nil was void.  Commenting out socket (with it's nil call) fixes this.
-  ;;
-    ;; (:socket .
-    ;;          ;; If emacs is run within TMUX/TMATE
-    ;;          ;; Let's go ahead and use our existing socket
-    ;;          ;; Otherwise we are likely wanting to launch our own
-    ;;          ,(if (getenv "TMUX")
-    ;;              (car (split-string (getenv "TMUX") ","))
-    ;;            (nil))
-    ;;          ))
+    (:dir . ".")
+    (:socket .
+             ;; if emacs is run within tmux/tmate
+             ;; let's go ahead and use our existing socket
+             ;; otherwise we are likely wanting to launch our own
+             ,(if (getenv "TMUX")
+                 (car (split-string (getenv "TMUX") ","))
+               (symbol-value nil))
+             ))
   "Default arguments to use when running tmate source blocks.")
 (add-to-list 'org-src-lang-modes '("tmate" . sh))
 ;;;;

--- a/packages.el
+++ b/packages.el
@@ -60,12 +60,19 @@
 (package! ob-sql-mode)
 (package! ob-tmux)
 (package! ox-gfm) ; org dispatch github flavoured markdown
+;; :build (:not compile) so we can edit in place
 (package! osc52e
-   :recipe (:local-repo "local/osc52e"))
+  :recipe (:local-repo "local/osc52e"
+           :no-byte-compile t
+           ))
 (package! iterm
-   :recipe (:local-repo "local/iterm"))
+  :recipe (:local-repo "local/iterm"
+           :no-byte-compile t
+           ))
 (package! ob-tmate
-   :recipe (:local-repo "local/ob-tmate"))
+   :recipe (:local-repo "local/ob-tmate"
+           :no-byte-compile t
+           ))
 
 ;;
 ; Lang

--- a/packages.el
+++ b/packages.el
@@ -57,6 +57,7 @@
 ;;
 ; Literate
 ;;
+(package! sql)
 (package! ob-sql-mode)
 (package! ob-tmux)
 (package! ox-gfm) ; org dispatch github flavoured markdown

--- a/packages.el
+++ b/packages.el
@@ -57,6 +57,8 @@
 ;;
 ; Literate
 ;;
+
+(package! graphviz-dot-mode)
 (package! sql)
 (package! ob-sql-mode)
 (package! ob-tmux)


### PR DESCRIPTION
This PR also adds support for big query sql-mode SRC org blocks:

```
#+TITLE: Sql                                                                                                                                                                                                               
◉ gcloud auth login                                                                                                                                                                                                        
  #+BEGIN_SRC tmate :window gcloud                                                                                                                                                                                         
  gcloud auth login                                                                                                                                                                                                        
  #+END_SRC                                                                                                                                                                                                                                                                                                                                                                                                                                           ◉ default to k8s-infra-ii-sandbox                                                                                                                                                                                          
  #+BEGIN_SRC shell                                                                                                                                                                                                        
  gcloud config set project k8s-infra-ii-sandbox                                                                                                                                                                           
  #+END_SRC                                                                                                                                                                                                                
                                                                                                                                                                                                                           
  #+RESULTS:                                                                                                                                                                                                               
  #+begin_example                                                                                                                                                                                                          
  #+end_example                                                                                                                                                                                                            
                                                                                                                                                                                                                           
◉ start bq shell in *SQL*                                                                                                                                                                                                  
                                                                                                                                                                                                                           
  This will create an SQLi (interactive) 'comint' buffer backed by a bq shell.                                                                                                                                             
  By default the name of the buffer is `*SQL*`                                                                                                                                                                             
  #+BEGIN_SRC elisp                                                                                                                                                                                                        
  (sql-product-interactive 'bq)                                                                                                                                                                                            
  #+END_SRC                                                                                                                                                                                                                
                                                                                                                                                                                                                           
  #+RESULTS:                                                                                                                                                                                                               
  #+begin_src elisp                                                                                                                                                                                                        
  #<buffer *SQL*>                                                                                                                                                                                                          
  #+end_src                                                                                                                                                                                                                
                                                                                                                                                                                                                           
◉ Org Block Execution of Big Query SRC blocks                                                                                                                                                                              
                                                                                                                                                                                                                           
  This will also create an SQLi buffer, but it's default name is `*SQL: bq:none*` and you can have multiple sessions.                                                                                                      
                                                                                                                                                                                                                           
  #+begin_src sql-mode :product bq                                                                                                                                                                                         
  select 1;                                                                                                                                                                                                                
  #+end_src                                                                                                                                                                                                                
                                                                                                                                                                                                                           
  #+RESULTS:                                                                                                                                                                                                               
  #+begin_SRC example                                                                                                                                                                                                      
  +-----+                                                                                                                                                                                                                  
  | f0_ |                                                                                                                                                                                                                  
  +-----+                                                                                                                                                                                                                  
  |   1 |                                                                                                                                                                                                                  
  +-----+                                                                                                                                                                                                                  
  #+end_SRC 
```