### PR TITLE
add git-link to packages.el

### DIFF
--- a/ii.org
+++ b/ii.org
@@ -501,3 +501,10 @@ See the docstrings of `defalias' and `make-obsolete' for more details."
 (package! almost-mono-themes)
 (package! graphviz-dot-mode)
 #+end_src
+
+[[https://github.com/sshaw/git-link][git-link]] provides a handy way to reference lines of code within org docs, by
+storing their full github link. This makes it easier to follow links in the org
+document when it is read on github.
+#+begin_src sql-mode
+(package! git-link)
+#+end_src

--- a/packages.el
+++ b/packages.el
@@ -21,3 +21,4 @@
 (package! feature-mode)
 (package! almost-mono-themes)
 (package! graphviz-dot-mode)
+(package! git-link)


### PR DESCRIPTION
this provides a handy way to reference lines of code within org docs, by storing their full github link, making it easier to follow the org file when browsing it on github.